### PR TITLE
[REFACTOR] 유효성 검사 매직 넘버 상수화 (#52)

### DIFF
--- a/app/mypage/email/change/page.tsx
+++ b/app/mypage/email/change/page.tsx
@@ -15,6 +15,7 @@ import AuthGuard from "@/components/auth/AuthGuard";
 import { handleError } from "@/lib/utils/errorHandler";
 import { useToast } from "@/hooks/useToast";
 import { SESSION_STORAGE_KEYS } from "@/constants/storageKeys";
+import { AUTH_CODE_LENGTH } from "@/constants/validation";
 
 const emailSchema = z.object({
   email: z
@@ -24,7 +25,9 @@ const emailSchema = z.object({
 });
 
 const codeSchema = z.object({
-  authCode: z.string().length(6, "인증코드는 6자리 숫자로 입력해주세요."),
+  authCode: z
+    .string()
+    .length(AUTH_CODE_LENGTH, "인증코드는 6자리 숫자로 입력해주세요."),
 });
 
 type EmailFormValues = z.infer<typeof emailSchema>;
@@ -207,11 +210,11 @@ function EmailChangePageContent() {
                                 field.onChange(
                                   e.target.value
                                     .replace(/[^0-9]/g, "")
-                                    .slice(0, 6),
+                                    .slice(0, AUTH_CODE_LENGTH),
                                 )
                               }
                               placeholder="인증코드 6자리 입력"
-                              maxLength={6}
+                              maxLength={AUTH_CODE_LENGTH}
                               className={`w-full ${codeForm.formState.errors.authCode ? "border-red-500" : ""}`}
                               autoComplete="one-time-code"
                             />

--- a/app/mypage/verify/page.tsx
+++ b/app/mypage/verify/page.tsx
@@ -15,6 +15,7 @@ import AuthGuard from "@/components/auth/AuthGuard";
 import { handleError } from "@/lib/utils/errorHandler";
 import { useToast } from "@/hooks/useToast";
 import { SESSION_STORAGE_KEYS } from "@/constants/storageKeys";
+import { AUTH_CODE_LENGTH } from "@/constants/validation";
 
 function EmailVerificationPageContent() {
   const router = useRouter();
@@ -69,7 +70,9 @@ function EmailVerificationPageContent() {
 
   const handleAuthCodeChange = (value: string) => {
     // 숫자만 허용, 6자리 제한
-    const numericValue = value.replace(/[^0-9]/g, "").slice(0, 6);
+    const numericValue = value
+      .replace(/[^0-9]/g, "")
+      .slice(0, AUTH_CODE_LENGTH);
     setAuthCode(numericValue);
   };
 
@@ -91,7 +94,7 @@ function EmailVerificationPageContent() {
       return;
     }
 
-    if (authCode.length !== 6) {
+    if (authCode.length !== AUTH_CODE_LENGTH) {
       toast({
         title: "입력 오류",
         description: "인증코드는 6자리 숫자로 입력해주세요.",
@@ -211,7 +214,7 @@ function EmailVerificationPageContent() {
                       value={authCode}
                       onChange={(e) => handleAuthCodeChange(e.target.value)}
                       placeholder="인증코드 6자리 입력"
-                      maxLength={6}
+                      maxLength={AUTH_CODE_LENGTH}
                       className="w-full"
                       autoComplete="one-time-code"
                     />

--- a/components/find-account/FindMemberTab.tsx
+++ b/components/find-account/FindMemberTab.tsx
@@ -10,6 +10,7 @@ import { findMemberNo, verifyMemberNo } from "@/lib/api/authMembers";
 import { handleError } from "@/lib/utils/errorHandler";
 import { useToast } from "@/hooks/useToast";
 import { SESSION_STORAGE_KEYS } from "@/constants/storageKeys";
+import { AUTH_CODE_LENGTH } from "@/constants/validation";
 
 export function FindMemberTab() {
   const [memberName, setMemberName] = useState("");
@@ -72,7 +73,7 @@ export function FindMemberTab() {
       return;
     }
 
-    if (!skipLengthCheck && authCode.length !== 6) {
+    if (!skipLengthCheck && authCode.length !== AUTH_CODE_LENGTH) {
       toast({
         title: "입력 오류",
         description: "인증 코드는 6자리여야 합니다.",
@@ -273,14 +274,14 @@ export function FindMemberTab() {
               placeholder="인증 코드 6자리를 입력하세요"
               value={authCode}
               onChange={handleAuthCodeChange}
-              className={`pl-10 ${authCode.length === 6 ? "border-green-500 focus:border-green-500" : ""}`}
-              maxLength={6}
+              className={`pl-10 ${authCode.length === AUTH_CODE_LENGTH ? "border-green-500 focus:border-green-500" : ""}`}
+              maxLength={AUTH_CODE_LENGTH}
               disabled={isLoading}
               autoComplete="one-time-code"
             />
             {authCode.length > 0 && (
               <div className="absolute right-3 top-1/2 transform -translate-y-1/2 text-xs text-gray-400">
-                {authCode.length}/6
+                {authCode.length}/{AUTH_CODE_LENGTH}
               </div>
             )}
           </div>

--- a/components/find-account/FindPasswordTab.tsx
+++ b/components/find-account/FindPasswordTab.tsx
@@ -11,6 +11,7 @@ import { updatePassword } from "@/lib/api/members";
 import { handleError } from "@/lib/utils/errorHandler";
 import { useToast } from "@/hooks/useToast";
 import { SESSION_STORAGE_KEYS } from "@/constants/storageKeys";
+import { AUTH_CODE_LENGTH, PASSWORD_MIN_LENGTH } from "@/constants/validation";
 
 export function FindPasswordTab() {
   const [passwordName, setPasswordName] = useState("");
@@ -97,7 +98,7 @@ export function FindPasswordTab() {
       return;
     }
 
-    if (!skipLengthCheck && passwordAuthCode.length !== 6) {
+    if (!skipLengthCheck && passwordAuthCode.length !== AUTH_CODE_LENGTH) {
       toast({
         title: "입력 오류",
         description: "인증 코드는 6자리여야 합니다.",
@@ -152,7 +153,7 @@ export function FindPasswordTab() {
       return;
     }
 
-    if (newPassword.length < 8) {
+    if (newPassword.length < PASSWORD_MIN_LENGTH) {
       toast({
         title: "입력 오류",
         description: "비밀번호는 8자 이상이어야 합니다.",
@@ -377,14 +378,14 @@ export function FindPasswordTab() {
                 placeholder="인증 코드 6자리를 입력하세요"
                 value={passwordAuthCode}
                 onChange={handlePasswordAuthCodeChange}
-                className={`pl-10 ${passwordAuthCode.length === 6 ? "border-green-500 focus:border-green-500" : ""}`}
-                maxLength={6}
+                className={`pl-10 ${passwordAuthCode.length === AUTH_CODE_LENGTH ? "border-green-500 focus:border-green-500" : ""}`}
+                maxLength={AUTH_CODE_LENGTH}
                 disabled={isLoading}
                 autoComplete="one-time-code"
               />
               {passwordAuthCode.length > 0 && (
                 <div className="absolute right-3 top-1/2 transform -translate-y-1/2 text-xs text-gray-400">
-                  {passwordAuthCode.length}/6
+                  {passwordAuthCode.length}/{AUTH_CODE_LENGTH}
                 </div>
               )}
             </div>

--- a/constants/validation.ts
+++ b/constants/validation.ts
@@ -1,0 +1,2 @@
+export const PASSWORD_MIN_LENGTH = 8; // 비밀번호 최소 길이
+export const AUTH_CODE_LENGTH = 6; // 이메일 인증 코드 자리 수

--- a/lib/validation/password.ts
+++ b/lib/validation/password.ts
@@ -1,3 +1,4 @@
+import { PASSWORD_MIN_LENGTH } from "@/constants/validation";
 import { z } from "zod";
 
 export const passwordSchema = z
@@ -5,7 +6,7 @@ export const passwordSchema = z
     newPassword: z
       .string()
       .min(1, "비밀번호를 입력해주세요.")
-      .min(8, "비밀번호는 8자 이상이어야 합니다."),
+      .min(PASSWORD_MIN_LENGTH, "비밀번호는 8자 이상이어야 합니다."),
     confirmPassword: z.string().min(1, "비밀번호 확인을 입력해주세요."),
   })
   .refine((data) => data.newPassword === data.confirmPassword, {

--- a/lib/validation/signup.ts
+++ b/lib/validation/signup.ts
@@ -1,3 +1,4 @@
+import { PASSWORD_MIN_LENGTH } from "@/constants/validation";
 import { z } from "zod";
 
 export const signupSchema = z
@@ -10,14 +11,14 @@ export const signupSchema = z
     password: z
       .string()
       .min(1, "비밀번호는 필수입니다.")
-      .min(8, "비밀번호는 8자 이상이어야 합니다."),
+      .min(PASSWORD_MIN_LENGTH, "비밀번호는 8자 이상이어야 합니다."),
     confirmPassword: z.string().min(1, "비밀번호 확인은 필수입니다."),
     phoneNumber: z.string().refine(
       (val) => {
         const digits = val.replace(/[^0-9]/g, "");
         return digits.length === 11;
       },
-      { message: "전화번호는 11자리 숫자여야 합니다." }
+      { message: "전화번호는 11자리 숫자여야 합니다." },
     ),
     birthDate: z
       .string()
@@ -25,7 +26,9 @@ export const signupSchema = z
       .regex(/^\d{4}-\d{2}-\d{2}$/, "생년월일을 모두 선택해주세요."),
     gender: z.enum(["M", "F"], { message: "성별을 선택해주세요." }),
     terms: z.literal(true, { message: "이용약관에 동의해주세요." }),
-    privacy: z.literal(true, { message: "개인정보 수집 및 이용에 동의해주세요." }),
+    privacy: z.literal(true, {
+      message: "개인정보 수집 및 이용에 동의해주세요.",
+    }),
     marketing: z.boolean(),
   })
   .refine((data) => data.password === data.confirmPassword, {


### PR DESCRIPTION
## 관련 이슈

closes #52 

## 변경 사항

  - `constants/validation.ts` 생성 (`PASSWORD_MIN_LENGTH`, `AUTH_CODE_LENGTH`)
  - 6개 파일의 매직 넘버 → 상수로 교체

## 리뷰어 참고 사항

  - `app/ticket/guest-booking/page.tsx`의 비회원 비밀번호 자리 수(`5`)는 기능 변경 가능성이 있어 이번 작업에서 제외
 
## 추가 정보

-
