### PR TITLE
[REFACTOR] useErrorToast 훅 생성 및 공통 에러 토스트 패턴 추출

### DIFF
--- a/components/find-account/FindMemberTab.tsx
+++ b/components/find-account/FindMemberTab.tsx
@@ -7,11 +7,10 @@ import { Label } from "@/components/ui/label";
 import { FileText, User, Mail, ArrowLeft } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { findMemberNo, verifyMemberNo } from "@/lib/api/authMembers";
-import { handleError } from "@/lib/utils/errorHandler";
-import { useToast } from "@/hooks/useToast";
 import { SESSION_STORAGE_KEYS } from "@/constants/storageKeys";
 import { AUTH_CODE_LENGTH } from "@/constants/validation";
 import LoadingSpinner from "../common/LoadingSpinner";
+import useErrorToast from "@/hooks/useErrorToast";
 
 export function FindMemberTab() {
   const [memberName, setMemberName] = useState("");
@@ -22,24 +21,16 @@ export function FindMemberTab() {
   const [authCode, setAuthCode] = useState("");
 
   const router = useRouter();
-  const { toast } = useToast();
+  const { showErrorToast } = useErrorToast();
 
   const handleFindMember = async () => {
     if (!memberName || !memberPhone) {
-      toast({
-        title: "입력 오류",
-        description: "이름과 휴대폰번호를 모두 입력해주세요.",
-        variant: "destructive",
-      });
+      showErrorToast("이름과 휴대폰번호를 모두 입력해주세요.", "입력 오류");
       return;
     }
 
     if (memberPhone.length !== 11) {
-      toast({
-        title: "입력 오류",
-        description: "휴대폰번호는 11자리여야 합니다.",
-        variant: "destructive",
-      });
+      showErrorToast("휴대폰 번호는 11자리여야 합니다.", "입력 오류");
       return;
     }
 
@@ -54,11 +45,7 @@ export function FindMemberTab() {
       setUserEmail(result.email);
       setShowVerification(true);
     } catch (error: unknown) {
-      toast({
-        title: "오류",
-        description: handleError(error, "회원번호 찾기에 실패했습니다."),
-        variant: "destructive",
-      });
+      showErrorToast(error, "회원번호 찾기에 실패했습니다.");
     } finally {
       setIsLoading(false);
     }
@@ -66,20 +53,12 @@ export function FindMemberTab() {
 
   const handleVerifyAuthCode = async (skipLengthCheck = false) => {
     if (!authCode) {
-      toast({
-        title: "입력 오류",
-        description: "인증 코드를 입력해주세요.",
-        variant: "destructive",
-      });
+      showErrorToast("인증 코드를 입력해주세요.", "입력 오류");
       return;
     }
 
     if (!skipLengthCheck && authCode.length !== AUTH_CODE_LENGTH) {
-      toast({
-        title: "입력 오류",
-        description: "인증 코드는 6자리여야 합니다.",
-        variant: "destructive",
-      });
+      showErrorToast("인증 코드는 6자리여야 합니다.", "입력 오류");
       return;
     }
 
@@ -97,11 +76,7 @@ export function FindMemberTab() {
       );
       router.push("/find-account/result");
     } catch (error: unknown) {
-      toast({
-        title: "오류",
-        description: handleError(error, "인증 코드 검증에 실패했습니다."),
-        variant: "destructive",
-      });
+      showErrorToast(error, "인증 코드 검증에 실패했습니다.");
     } finally {
       setIsLoading(false);
     }

--- a/components/find-account/FindPasswordTab.tsx
+++ b/components/find-account/FindPasswordTab.tsx
@@ -9,10 +9,10 @@ import { useRouter } from "next/navigation";
 import { findPassword, verifyPassword } from "@/lib/api/authMembers";
 import { updatePassword } from "@/lib/api/members";
 import { handleError } from "@/lib/utils/errorHandler";
-import { useToast } from "@/hooks/useToast";
 import { SESSION_STORAGE_KEYS } from "@/constants/storageKeys";
 import { AUTH_CODE_LENGTH, PASSWORD_MIN_LENGTH } from "@/constants/validation";
 import LoadingSpinner from "../common/LoadingSpinner";
+import useErrorToast from "@/hooks/useErrorToast";
 
 export function FindPasswordTab() {
   const [passwordName, setPasswordName] = useState("");
@@ -32,7 +32,7 @@ export function FindPasswordTab() {
   );
 
   const router = useRouter();
-  const { toast } = useToast();
+  const { showErrorToast } = useErrorToast();
 
   // sessionStorage에서 비밀번호 찾기 상태 복원
   useEffect(() => {
@@ -60,11 +60,7 @@ export function FindPasswordTab() {
 
   const handleFindPassword = async () => {
     if (!passwordName || !passwordMemberNumber) {
-      toast({
-        title: "입력 오류",
-        description: "이름과 회원번호를 모두 입력해주세요.",
-        variant: "destructive",
-      });
+      showErrorToast("이름과 회원 번호를 모두 입력해주세요.", "입력 오류");
       return;
     }
 
@@ -79,11 +75,7 @@ export function FindPasswordTab() {
       setPasswordUserEmail(result.email);
       setShowPasswordVerification(true);
     } catch (error: unknown) {
-      toast({
-        title: "오류",
-        description: handleError(error, "비밀번호 찾기에 실패했습니다."),
-        variant: "destructive",
-      });
+      showErrorToast(error, "비밀번호 찾기에 실패했습니다.");
     } finally {
       setIsLoading(false);
     }
@@ -91,20 +83,12 @@ export function FindPasswordTab() {
 
   const handleVerifyPasswordAuthCode = async (skipLengthCheck = false) => {
     if (!passwordAuthCode) {
-      toast({
-        title: "입력 오류",
-        description: "인증 코드를 입력해주세요.",
-        variant: "destructive",
-      });
+      showErrorToast("인증 코드를 입력해주세요.", "입력 오류");
       return;
     }
 
     if (!skipLengthCheck && passwordAuthCode.length !== AUTH_CODE_LENGTH) {
-      toast({
-        title: "입력 오류",
-        description: "인증 코드는 6자리여야 합니다.",
-        variant: "destructive",
-      });
+      showErrorToast("인증 코드는 6자리여야 합니다.", "입력 오류");
       return;
     }
 
@@ -125,11 +109,7 @@ export function FindPasswordTab() {
       );
       setShowPasswordChange(true);
     } catch (error: unknown) {
-      toast({
-        title: "오류",
-        description: handleError(error, "인증 코드 검증에 실패했습니다."),
-        variant: "destructive",
-      });
+      showErrorToast(error, "인증 코드 검증에 실패했습니다.");
     } finally {
       setIsLoading(false);
     }
@@ -137,29 +117,23 @@ export function FindPasswordTab() {
 
   const handleChangePassword = async () => {
     if (!newPassword || !confirmPassword) {
-      toast({
-        title: "입력 오류",
-        description: "새 비밀번호와 확인 비밀번호를 모두 입력해주세요.",
-        variant: "destructive",
-      });
+      showErrorToast(
+        "새 비밀번호와 확인 비밀번호를 모두 입력해주세요.",
+        "입력 오류",
+      );
       return;
     }
 
     if (newPassword !== confirmPassword) {
-      toast({
-        title: "입력 오류",
-        description: "새 비밀번호와 확인 비밀번호가 일치하지 않습니다.",
-        variant: "destructive",
-      });
+      showErrorToast(
+        "새 비밀번호와 확인 비밀번호가 일치하지 않습니다.",
+        "입력 오류",
+      );
       return;
     }
 
     if (newPassword.length < PASSWORD_MIN_LENGTH) {
-      toast({
-        title: "입력 오류",
-        description: "비밀번호는 8자 이상이어야 합니다.",
-        variant: "destructive",
-      });
+      showErrorToast("비밀번호는 8자 이상이어야 합니다.", "입력 오류");
       return;
     }
 
@@ -172,11 +146,7 @@ export function FindPasswordTab() {
         temporaryToken;
 
       if (!token) {
-        toast({
-          title: "오류",
-          description: "임시 토큰이 만료되었습니다. 다시 인증해주세요.",
-          variant: "destructive",
-        });
+        showErrorToast("임시 토큰이 만료되었습니다. 다시 인증해주세요.");
         handleBackToPasswordFind();
         return;
       }
@@ -191,11 +161,7 @@ export function FindPasswordTab() {
         router.push("/login");
       }, 3000);
     } catch (error: unknown) {
-      toast({
-        title: "오류",
-        description: handleError(error, "비밀번호 변경에 실패했습니다."),
-        variant: "destructive",
-      });
+      showErrorToast(error, "비밀번호 변경에 실패했습니다.");
       setTemporaryToken("");
       sessionStorage.removeItem(SESSION_STORAGE_KEYS.PASSWORD_RESET_TOKEN);
       sessionStorage.removeItem(SESSION_STORAGE_KEYS.PASSWORD_RESET_EMAIL);

--- a/hooks/useErrorToast.ts
+++ b/hooks/useErrorToast.ts
@@ -1,0 +1,42 @@
+import { useToast } from "./useToast";
+import { handleError } from "@/lib/utils/errorHandler";
+
+const useErrorToast = () => {
+  const { toast } = useToast();
+
+  function showErrorToast(message: string, title?: string): void;
+  function showErrorToast(
+    error: unknown,
+    defaultMessage: string,
+    title?: string,
+  ): void;
+  function showErrorToast(
+    errorOrMessage: unknown,
+    defaultMessageOrTitle?: string,
+    title?: string,
+  ): void {
+    let description: string;
+    let resolvedTitle: string;
+
+    if (typeof errorOrMessage === "string") {
+      description = errorOrMessage;
+      resolvedTitle = defaultMessageOrTitle ?? "오류";
+    } else {
+      description = handleError(
+        errorOrMessage,
+        defaultMessageOrTitle ?? "오류가 발생했습니다.",
+      );
+      resolvedTitle = title ?? "오류";
+    }
+
+    toast({
+      title: resolvedTitle,
+      description,
+      variant: "destructive",
+    });
+  }
+
+  return { showErrorToast };
+};
+
+export default useErrorToast;


### PR DESCRIPTION
## 관련 이슈

closes #56 

## 변경 사항

  - `hooks/useErrorToast.ts` 생성 — 문자열/error 객체 두 패턴을 오버로드로 처리
  - `FindMemberTab.tsx` 적용
  - `FindPasswordTab.tsx` 적용

## 리뷰어 참고 사항

  - `variant: "destructive"` toast 전부 `showErrorToast`로 통일
  - 나머지 파일은 F 항목 작업 시 점진적으로 적용 예정

## 추가 정보

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated error message handling for account lookup flows for improved consistency.

* **Bug Fixes**
  * Updated phone number validation error messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/penggu-dev/raillo-frontend/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->