### PR TITLE
[REFACTOR] searchHistory 유틸 생성 및 검색 기록 로직 통합 (#58)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,7 +25,7 @@ import { DateTimeSelector } from "@/components/ticket/search/date-time-selector"
 import { PassengerSelector } from "@/components/ticket/search/passenger-selector";
 import type { PassengerCounts } from "@/types/passengerType";
 import { useToast } from "@/hooks/useToast";
-import { LOCAL_STORAGE_KEYS } from "@/constants/storageKeys";
+import { saveSearchHistory } from "@/lib/utils/searchHistory";
 
 export default function HomePage() {
   const router = useRouter();
@@ -45,12 +45,6 @@ export default function HomePage() {
     veteran: 0,
   });
 
-  type SearchHistoryItem = {
-    departure: string;
-    arrival: string;
-    timestamp: number;
-  };
-
   const handleSearch = async () => {
     if (!departureStation || !arrivalStation || !departureDate) {
       toast({
@@ -62,45 +56,7 @@ export default function HomePage() {
     }
 
     // 검색 기록 저장
-    const searchHistory = {
-      departure: departureStation,
-      arrival: arrivalStation,
-      timestamp: Date.now(),
-    };
-
-    const existingHistory = localStorage.getItem(
-      LOCAL_STORAGE_KEYS.SEARCH_HISTORY,
-    );
-
-    let history: SearchHistoryItem[] = [];
-
-    if (existingHistory) {
-      try {
-        const parsed = JSON.parse(existingHistory);
-        history = Array.isArray(parsed) ? parsed : [];
-      } catch {
-        // 파싱 실패 시 빈 배열로 시작
-      }
-    }
-
-    // 중복 제거
-    history = history.filter(
-      (item) =>
-        !(
-          item.departure === departureStation && item.arrival === arrivalStation
-        ),
-    );
-
-    // 새 기록을 맨 앞에 추가
-    history.unshift(searchHistory);
-
-    // 최대 5개까지만 저장
-    history = history.slice(0, 5);
-
-    localStorage.setItem(
-      LOCAL_STORAGE_KEYS.SEARCH_HISTORY,
-      JSON.stringify(history),
-    );
+    saveSearchHistory(departureStation, arrivalStation);
 
     const params = new URLSearchParams({
       departure: departureStation,

--- a/app/ticket/search/page.tsx
+++ b/app/ticket/search/page.tsx
@@ -25,8 +25,8 @@ import type {
 } from "@/types/trainType";
 import type { PassengerCounts } from "@/types/passengerType";
 import { useToast } from "@/hooks/useToast";
-import { LOCAL_STORAGE_KEYS } from "@/constants/storageKeys";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
+import { saveSearchHistory } from "@/lib/utils/searchHistory";
 
 function TrainSearchPage() {
   const router = useRouter();
@@ -61,8 +61,6 @@ function TrainSearchPage() {
     d.setHours(Number(hour), 0, 0, 0);
     return d;
   }, [dateStr, hour]);
-
-  const [allTrains, setAllTrains] = useState<TrainSchedule[]>([]);
   const [displayedTrains, setDisplayedTrains] = useState<TrainSchedule[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -104,45 +102,10 @@ function TrainSearchPage() {
   const fetchTrainsFromAPI = async () => {
     setLoading(true);
 
+    // 검색 기록 저장
+    saveSearchHistory(departureStation, arrivalStation);
+
     try {
-      // 검색 기록 저장
-      const searchHistory = {
-        departure: departureStation,
-        arrival: arrivalStation,
-        timestamp: Date.now(),
-      };
-
-      const existingHistory = localStorage.getItem(
-        LOCAL_STORAGE_KEYS.SEARCH_HISTORY,
-      );
-      let historyArray: {
-        departure: string;
-        arrival: string;
-        timestamp: number;
-      }[] = [];
-
-      if (existingHistory) {
-        try {
-          historyArray = JSON.parse(existingHistory);
-        } catch {
-          // 파싱 실패 시 빈 배열로 시작
-        }
-      }
-
-      historyArray = historyArray.filter(
-        (item) =>
-          !(
-            item.departure === searchHistory.departure &&
-            item.arrival === searchHistory.arrival
-          ),
-      );
-      historyArray.unshift(searchHistory);
-      historyArray = historyArray.slice(0, 3);
-      localStorage.setItem(
-        LOCAL_STORAGE_KEYS.SEARCH_HISTORY,
-        JSON.stringify(historyArray),
-      );
-
       const totalPassengers = Object.values(passengerCounts).reduce(
         (sum: number, count: unknown) => sum + (count as number),
         0,
@@ -174,7 +137,6 @@ function TrainSearchPage() {
         ? result.content
         : [];
 
-      setAllTrains(resultArray);
       setDisplayedTrains(resultArray);
       setTotalResults(result.totalElements || resultArray.length);
       setHasNext(result.hasNext ?? false);
@@ -184,7 +146,6 @@ function TrainSearchPage() {
         description: handleError(error, "열차 검색에 실패했습니다."),
         variant: "destructive",
       });
-      setAllTrains([]);
       setDisplayedTrains([]);
       setTotalResults(0);
       setHasNext(false);
@@ -337,7 +298,6 @@ function TrainSearchPage() {
         ? result.content
         : [];
 
-      setAllTrains((prev) => [...prev, ...newTrains]);
       setDisplayedTrains((prev) => [...prev, ...newTrains]);
       setCurrentPage(nextPage);
       setHasNext(result.hasNext ?? false);

--- a/components/ticket/search/station-selector.tsx
+++ b/components/ticket/search/station-selector.tsx
@@ -8,6 +8,7 @@ import { Search, MapPin, X, Clock, ArrowRight } from "lucide-react";
 import { STATIONS, stationUtils } from "@/constants/stations";
 import type { Station } from "@/types/trainType";
 import { LOCAL_STORAGE_KEYS } from "@/constants/storageKeys";
+import { getSearchHistory, SearchHistoryItem } from "@/lib/utils/searchHistory";
 
 interface StationSelectorProps {
   value: string;
@@ -21,41 +22,23 @@ interface StationSelectorProps {
   hideHistory?: boolean; // 검색 기록 숨기기
 }
 
-interface SearchHistory {
-  departure: string;
-  arrival: string;
-  timestamp: number;
-}
-const MAX_HISTORY_ITEMS = 3;
-
 export function StationSelector({
   value,
   onValueChange,
   placeholder,
   label,
   variant = "blue",
-  otherStation = "",
   onBothStationsChange,
   disabled,
   hideHistory = false,
 }: StationSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
-  const [searchHistory, setSearchHistory] = useState<SearchHistory[]>([]);
+  const [searchHistory, setSearchHistory] = useState<SearchHistoryItem[]>([]);
 
   // 검색 기록 로드
   useEffect(() => {
-    const savedHistory = localStorage.getItem(
-      LOCAL_STORAGE_KEYS.SEARCH_HISTORY,
-    );
-    if (savedHistory) {
-      try {
-        const history = JSON.parse(savedHistory) as SearchHistory[];
-        setSearchHistory(history.slice(0, MAX_HISTORY_ITEMS));
-      } catch {
-        // 파싱 실패 시 검색 기록 없이 시작
-      }
-    }
+    setSearchHistory(getSearchHistory());
   }, []);
 
   const filteredStations = useMemo(() => {
@@ -69,7 +52,7 @@ export function StationSelector({
     setSearchTerm("");
   };
 
-  const handleHistorySelect = (history: SearchHistory) => {
+  const handleHistorySelect = (history: SearchHistoryItem) => {
     if (onBothStationsChange) {
       // 두 역을 동시에 변경
       onBothStationsChange(history.departure, history.arrival);

--- a/constants/validation.ts
+++ b/constants/validation.ts
@@ -1,2 +1,4 @@
 export const PASSWORD_MIN_LENGTH = 8; // 비밀번호 최소 길이
 export const AUTH_CODE_LENGTH = 6; // 이메일 인증 코드 자리 수
+
+export const SEARCH_HISTORY_MAX = 3; // 검색 기록 최대 저장 개수

--- a/hooks/useErrorToast.ts
+++ b/hooks/useErrorToast.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useToast } from "./useToast";
 import { handleError } from "@/lib/utils/errorHandler";
 

--- a/lib/utils/searchHistory.ts
+++ b/lib/utils/searchHistory.ts
@@ -7,6 +7,10 @@ export type SearchHistoryItem = {
   timestamp: number;
 };
 
+// 검색 기록 저장 함수
+// 출발점과 도착점을 파라미터로 받아
+// 중복된 사항이 있는지 확인 및 제거한 후
+// 기존에 있던 항목 앞에 새 검색 항목을 추가
 export const saveSearchHistory = (departure: string, arrival: string): void => {
   const existing = localStorage.getItem(LOCAL_STORAGE_KEYS.SEARCH_HISTORY);
 
@@ -34,6 +38,7 @@ export const saveSearchHistory = (departure: string, arrival: string): void => {
   );
 };
 
+// 로컬스토리지에서 검색 항목을 불러옴
 export const getSearchHistory = (): SearchHistoryItem[] => {
   const existing = localStorage.getItem(LOCAL_STORAGE_KEYS.SEARCH_HISTORY);
 

--- a/lib/utils/searchHistory.ts
+++ b/lib/utils/searchHistory.ts
@@ -1,0 +1,48 @@
+import { LOCAL_STORAGE_KEYS } from "@/constants/storageKeys";
+import { SEARCH_HISTORY_MAX } from "@/constants/validation";
+
+export type SearchHistoryItem = {
+  departure: string;
+  arrival: string;
+  timestamp: number;
+};
+
+export const saveSearchHistory = (departure: string, arrival: string): void => {
+  const existing = localStorage.getItem(LOCAL_STORAGE_KEYS.SEARCH_HISTORY);
+
+  let history: SearchHistoryItem[] = [];
+
+  if (existing) {
+    try {
+      const parsed = JSON.parse(existing);
+      if (Array.isArray(parsed)) history = parsed;
+    } catch {
+      history = [];
+    }
+  }
+
+  history = history.filter(
+    (item) => !(item.departure === departure && item.arrival === arrival),
+  );
+
+  history.unshift({ departure, arrival, timestamp: Date.now() });
+  history.slice(0, SEARCH_HISTORY_MAX);
+
+  localStorage.setItem(
+    LOCAL_STORAGE_KEYS.SEARCH_HISTORY,
+    JSON.stringify(history),
+  );
+};
+
+export const getSearchHistory = (): SearchHistoryItem[] => {
+  const existing = localStorage.getItem(LOCAL_STORAGE_KEYS.SEARCH_HISTORY);
+
+  if (!existing) return [];
+
+  try {
+    const parsed = JSON.parse(existing);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};

--- a/lib/utils/searchHistory.ts
+++ b/lib/utils/searchHistory.ts
@@ -30,7 +30,7 @@ export const saveSearchHistory = (departure: string, arrival: string): void => {
   );
 
   history.unshift({ departure, arrival, timestamp: Date.now() });
-  history.slice(0, SEARCH_HISTORY_MAX);
+  history = history.slice(0, SEARCH_HISTORY_MAX);
 
   localStorage.setItem(
     LOCAL_STORAGE_KEYS.SEARCH_HISTORY,


### PR DESCRIPTION
## 관련 이슈

closes #58 

## 변경 사항

  - `constants/validation.ts`에 `SEARCH_HISTORY_MAX = 3` 추가
  - `lib/utils/searchHistory.ts` 생성 — 중복 제거 + 최대 3개 저장
  - `app/page.tsx` 적용
  - `app/ticket/search/page.tsx` 적용

## 리뷰어 참고 사항

  - 기존 `app/page.tsx`(최대 5개, 중복 제거 없음)와 `ticket/search/page.tsx`(최대 3개, 중복 제거 있음) 동작 불일치를 최대 3개 + 중복 제거로 통일
  - `SearchHistoryItem` 타입은 `searchHistory.ts`에서 export

## 추가 정보

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated search history persistence logic from multiple components into a centralized shared utility to reduce code duplication and improve consistency across features
  * Implemented configurable search history management limiting stored entries to a maximum of 3 for better performance
  * Optimized search results state to reduce memory usage during pagination and result fetching operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/penggu-dev/raillo-frontend/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->