### PR TITLE
[REFACTOR] hasValidToken() auth-store로 통일 (#60)

### DIFF
--- a/app/ticket/search/page.tsx
+++ b/app/ticket/search/page.tsx
@@ -372,23 +372,14 @@ function TrainSearchPage() {
       .filter((id) => id > 0);
   };
 
-  const hasValidAccessToken = () => {
-    const { accessToken, tokenExpiresIn } = useAuthStore.getState();
-    return (
-      Boolean(accessToken) &&
-      Boolean(tokenExpiresIn) &&
-      Date.now() < (tokenExpiresIn ?? 0)
-    );
-  };
-
   const handleBooking = async () => {
     if (!selectedTrain) return;
 
-    if (!hasValidAccessToken()) {
+    if (!useAuthStore.getState().hasValidToken()) {
       await initializeAuth();
     }
 
-    if (!hasValidAccessToken()) {
+    if (!useAuthStore.getState().hasValidToken()) {
       const currentPath =
         typeof window !== "undefined"
           ? window.location.pathname + window.location.search

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -10,14 +10,9 @@ interface UseAuthOptions {
 
 export function useAuth(options: UseAuthOptions = {}) {
   const { redirectTo = "/login", requireAuth = true, redirectPath } = options;
-  const { accessToken, tokenExpiresIn, isInitialized, initialize } =
-    useAuthStore();
+  const { isInitialized, initialize, isAuthenticated } = useAuthStore();
   const router = useRouter();
 
-  const isAuthenticated =
-    Boolean(accessToken) &&
-    Boolean(tokenExpiresIn) &&
-    Date.now() < (tokenExpiresIn ?? 0);
   const isLoading = !isInitialized;
 
   const checkAuth = useCallback(() => {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -60,9 +60,9 @@ const getDefaultHeaders = async (): Promise<Record<string, string>> => {
   };
 
   // 토큰이 있고 유효하면 Authorization 헤더 추가
-  const token = useAuthStore.getState().getToken();
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
+  const authState = useAuthStore.getState();
+  if (authState.hasValidToken()) {
+    headers.Authorization = `Bearer ${authState.getToken()}`;
   }
 
   return headers;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -53,15 +53,6 @@ export class ApiError extends Error {
 
 export const UNAUTHORIZED_ERROR_CODE = "UNAUTHORIZED";
 
-const hasValidAccessToken = (): boolean => {
-  const { accessToken, tokenExpiresIn } = useAuthStore.getState();
-  return (
-    Boolean(accessToken) &&
-    Boolean(tokenExpiresIn) &&
-    Date.now() < (tokenExpiresIn ?? 0)
-  );
-};
-
 // 기본 헤더 설정 (토큰 자동 포함)
 const getDefaultHeaders = async (): Promise<Record<string, string>> => {
   const headers: Record<string, string> = {
@@ -69,11 +60,9 @@ const getDefaultHeaders = async (): Promise<Record<string, string>> => {
   };
 
   // 토큰이 있고 유효하면 Authorization 헤더 추가
-  if (hasValidAccessToken()) {
-    const token = useAuthStore.getState().getToken();
-    if (token) {
-      headers.Authorization = `Bearer ${token}`;
-    }
+  const token = useAuthStore.getState().getToken();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
   }
 
   return headers;


### PR DESCRIPTION
## 관련 이슈

closes #60 

## 변경 사항

  - lib/api.ts 로컬 hasValidAccessToken 함수 제거
  - app/ticket/search/page.tsx 로컬 hasValidAccessToken 함수 제거 → hasValidToken() 적용
  - hooks/useAuth.ts 인라인 로직 제거 → store isAuthenticated 직접 구독

## 리뷰어 참고 사항

  - useAuth.ts는 accessToken/tokenExpiresIn 직접 구독 대신 store의 isAuthenticated 필드를 구독하도록 변경

## 추가 정보

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved authentication token management and validation by centralizing auth state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->